### PR TITLE
Joystick Normalization and Compensation

### DIFF
--- a/container.py
+++ b/container.py
@@ -39,9 +39,9 @@ class RobotContainer:
         self.robot_centric_command = self.drivetrain.runOnce(
             lambda: self.drivetrain.drive_robot_centric(
                 ChassisSpeeds(
-                   -(self.driver_controller.getLeftY() ** 3) * Constants.Drivetrain.k_max_attainable_speed, # Speed forward and backward 
-                   -(self.driver_controller.getLeftX() ** 3) * Constants.Drivetrain.k_max_attainable_speed, # Speed Left and right
-                   -(self.driver_controller.getRightX() ** 3) * Constants.Drivetrain.k_max_rot_rate # Rotation speed
+                   -(self.normalize_joystick_input(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[1]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed forward and backward 
+                   -(self.normalize_joystick_input(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[0]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed Left and right
+                   -(self.driver_controller.getRightX()) * Constants.Drivetrain.k_max_rot_rate # Rotation speed
                 )
             )
         ).repeatedly() # Tells it to run the command forever until we tell it not to.
@@ -49,8 +49,8 @@ class RobotContainer:
         self.field_relative_command = self.drivetrain.runOnce(
             lambda: self.drivetrain.drive_field_relative(
                 ChassisSpeeds(
-                   -(self.diag_stick_fix(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[1]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed forward and backward 
-                   -(self.diag_stick_fix(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[0]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed Left and right
+                   -(self.normalize_joystick_input(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[1]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed forward and backward 
+                   -(self.normalize_joystick_input(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[0]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed Left and right
                    -(self.driver_controller.getRightX()) * Constants.Drivetrain.k_max_rot_rate # Rotation speed
                 ) 
             )
@@ -84,7 +84,7 @@ class RobotContainer:
             )
         )
     
-    def diag_stick_fix(self, x, y):
+    def normalize_joystick_input(self, x, y):
         """
         Change the maximum diagonal value of the joystick to 1
         """

--- a/container.py
+++ b/container.py
@@ -3,7 +3,7 @@ from commands2.button import JoystickButton
 from pathplannerlib.auto import PathPlannerAuto
 from pathplannerlib.path import PathConstraints
 
-from wpilib import SendableChooser, XboxController
+from wpilib import SendableChooser, XboxController, SmartDashboard
 from wpilib.shuffleboard import BuiltInWidgets, Shuffleboard
 from wpimath.geometry import Pose2d, Rotation2d
 from wpimath.kinematics import ChassisSpeeds
@@ -52,7 +52,6 @@ class RobotContainer:
                    -(self.diag_stick_fix(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[1]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed forward and backward 
                    -(self.diag_stick_fix(self.driver_controller.getLeftX(), self.driver_controller.getLeftY())[0]) ** 3 * Constants.Drivetrain.k_max_attainable_speed, # Speed Left and right
                    -(self.driver_controller.getRightX()) * Constants.Drivetrain.k_max_rot_rate # Rotation speed
-                   
                 ) 
             )
         ).repeatedly()
@@ -89,13 +88,10 @@ class RobotContainer:
         """
         Change the maximum diagonal value of the joystick to 1
         """
-
-        # Find magnitude of joystick
-        joystickmag = math.sqrt(x ** 2 + y ** 2)
         
-        # Normalize X and Y values and multiply normalized values by the magnitude
-        newX, newY = x/max(abs(x), abs(y))*joystickmag, y/max(abs(x), abs(y))*joystickmag
+        # Normalize X and Y and multiply by the magnitude
+        mag = math.sqrt(x ** 2 + y ** 2)
+        x, y = x / max(abs(x), abs(y)) * mag, y / max(abs(x), abs(y)) * mag
 
-        # return new values
-        return (newX, newY)
+        return (x, y)
     

--- a/container.py
+++ b/container.py
@@ -3,9 +3,8 @@ from commands2.button import JoystickButton
 from pathplannerlib.auto import PathPlannerAuto
 from pathplannerlib.path import PathConstraints
 
-from wpilib import SendableChooser, XboxController, SmartDashboard
+from wpilib import SendableChooser, XboxController
 from wpilib.shuffleboard import BuiltInWidgets, Shuffleboard
-from wpimath.geometry import Pose2d, Rotation2d
 from wpimath.kinematics import ChassisSpeeds
 
 from constants import Constants

--- a/container.py
+++ b/container.py
@@ -94,7 +94,7 @@ class RobotContainer:
         joystickmag = math.sqrt(x ** 2 + y ** 2)
         
         # Normalize X and Y values and multiply normalized values by the magnitude
-        newX, newY = x/max(x, y)*joystickmag, y/max(x, y)*joystickmag
+        newX, newY = x/max(abs(x), abs(y))*joystickmag, y/max(abs(x), abs(y))*joystickmag
 
         # return new values
         return (newX, newY)

--- a/robot.py
+++ b/robot.py
@@ -3,7 +3,7 @@ from container import RobotContainer
 
 import math
 
-from wpilib import CameraServer, DataLogManager, DriverStation, SmartDashboard
+from wpilib import CameraServer, DataLogManager, DriverStation
 from wpimath.geometry import Pose2d, Rotation2d
 
 class Waffles(TimedCommandRobot):
@@ -24,14 +24,7 @@ class Waffles(TimedCommandRobot):
 
     # Most of these are all here to suppress warnings
     def robotPeriodic(self) -> None:
-        controller = self.container.driver_controller
-        x = controller.getLeftX()
-        y = controller.getLeftY()
-
-        SmartDashboard.putNumber("Controller X", x)
-        SmartDashboard.putNumber("Controller Y", y)
-
-        SmartDashboard.putNumber("Controller Angle", math.degrees(math.atan2(y, x)) + 90)
+        pass
     
     def _simulationPeriodic(self) -> None:
         pass


### PR DESCRIPTION
Basically, when driving on a joystick, it's impossible for both the X and Y axes on a joystick to both equal their maximum magnitude of 1. This normalizes both axes and compensates for this for faster teleop driving with more accurate diagonal steering.